### PR TITLE
Add vercel.json to handle SPA routing and prevent 404 errors

### DIFF
--- a/devbyte-frontend/vercel.json
+++ b/devbyte-frontend/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
This PR adds a vercel.json file at the project root to configure rewrite rules for Vercel.

Why:
Currently, deploying the frontend SPA to Vercel results in a 404: NOT_FOUND error on routes other than /. This happens because Vercel tries to serve static files for each route, but a client-side routed SPA relies on index.html.

What was done:

Added vercel.json with the following rewrite configuration:

{
  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
}


Ensures all routes fallback to index.html, allowing React Router (or any client-side router) to handle routing.

Impact:

Prevents 404 errors on direct navigation to SPA routes.

Does not affect existing static assets or root route.